### PR TITLE
Feature/module name cornerstone core (#149)

### DIFF
--- a/config/webpack/webpack-base.js
+++ b/config/webpack/webpack-base.js
@@ -13,7 +13,12 @@ module.exports = {
   target: 'web',
   output: {
     filename: '[name].js',
-    library: '[name]',
+    library: {
+      commonjs: "cornerstone-core",
+      commonjs2: "cornerstone-core",
+      amd: "cornerstone-core",
+      root: 'cornerstone'
+    },
     libraryTarget: 'umd',
     path: outputPath,
     umdNamedDefine: true
@@ -21,6 +26,9 @@ module.exports = {
   devtool: 'source-map',
   externals: {
     jquery: {
+      commonjs: "jquery",
+      commonjs2: "jquery",
+      amd: "jquery",
       root: '$'
     }
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "phantomjs-polyfill-find": "github:ptim/phantomjs-polyfill-find",
     "phantomjs-polyfill-find-index": "^1.0.1",
     "shx": "^0.2.2",
-    "webpack": "^2.4.1"
+    "webpack": "^3.1.0"
   },
   "dependencies": {
     "jquery": "^2.2.4"

--- a/src/disable.js
+++ b/src/disable.js
@@ -1,3 +1,4 @@
+import $ from './jquery.js';
 import { getEnabledElements } from './enabledElements.js';
 
 /**

--- a/src/displayImage.js
+++ b/src/displayImage.js
@@ -1,3 +1,4 @@
+import $ from './jquery.js';
 import { getEnabledElement } from './enabledElements.js';
 import getDefaultViewport from './internal/getDefaultViewport.js';
 import updateImage from './updateImage.js';

--- a/src/enable.js
+++ b/src/enable.js
@@ -2,6 +2,7 @@
  * This module is responsible for enabling an element to display images with cornerstone
  */
 
+import $ from './jquery.js';
 import { addEnabledElement } from './enabledElements.js';
 import resize from './resize.js';
 import drawImageSync from './internal/drawImageSync.js';

--- a/src/imageCache.js
+++ b/src/imageCache.js
@@ -10,6 +10,7 @@ const imageCacheDict = {};
 // Array of cachedImage objects
 export const cachedImages = [];
 
+import $ from './jquery.js';
 import events from './events.js';
 
 export function setMaximumSizeBytes (numBytes) {

--- a/src/imageLoader.js
+++ b/src/imageLoader.js
@@ -1,6 +1,8 @@
 /**
  * This module deals with ImageLoaders, loading images and caching images
  */
+
+import $ from './jquery.js';
 import { getImagePromise, putImagePromise } from './imageCache.js';
 import events from './events.js';
 

--- a/src/internal/drawImageSync.js
+++ b/src/internal/drawImageSync.js
@@ -1,3 +1,4 @@
+import $ from '../jquery.js';
 import now from './now.js';
 import drawCompositeImage from './drawCompositeImage.js';
 import { renderColorImage } from '../rendering/renderColorImage.js';

--- a/src/invalidate.js
+++ b/src/invalidate.js
@@ -2,6 +2,7 @@
  * This module contains a function to make an image is invalid
  */
 
+import $ from './jquery.js';
 import { getEnabledElement } from './enabledElements.js';
 
 /**

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -1,0 +1,7 @@
+/*
+ * When loading sources directly with <script type="module"> remove the line below
+ * (keep only the export line)
+ */
+import $ from 'jquery';
+
+export default $;

--- a/src/layers.js
+++ b/src/layers.js
@@ -1,3 +1,4 @@
+import $ from './jquery.js';
 import guid from './internal/guid.js';
 import { getEnabledElement } from './enabledElements.js';
 import metaData from './metaData.js';

--- a/src/resize.js
+++ b/src/resize.js
@@ -1,3 +1,4 @@
+import $ from './jquery.js';
 import { getEnabledElement } from './enabledElements.js';
 import fitToWindow from './fitToWindow.js';
 import updateImage from './updateImage.js';

--- a/src/webgl/textureCache.js
+++ b/src/webgl/textureCache.js
@@ -1,3 +1,4 @@
+import $ from '../jquery.js';
 import events from '../events.js';
 
 /**


### PR DESCRIPTION
* Module name: cornerstone-core

* add jquery names for commonjs, commonjs2 and amd

* Undo removing dist/ files (Mishandling)

* import $ from 'jquery';

* Same method than in cornerstoneTools to import jQuery: Use an intermediate file src/jquery.js, in which we can remove the import line to load the sources directly).