### PR TITLE
Avoid setting canva's size with the same value

### DIFF
--- a/src/resize.js
+++ b/src/resize.js
@@ -32,10 +32,16 @@ function setCanvasSize (element, canvas) {
     }
     */
 
-  canvas.width = element.clientWidth;
-  canvas.height = element.clientHeight;
-  canvas.style.width = `${element.clientWidth}px`;
-  canvas.style.height = `${element.clientHeight}px`;
+  // Avoid setting the same value because it flashes the canvas with IE and Edge
+  if (canvas.width !== element.clientWidth) {
+    canvas.width = element.clientWidth;
+    canvas.style.width = `${element.clientWidth}px`;
+  }
+  // Avoid setting the same value because it flashes the canvas with IE and Edge
+  if (canvas.height !== element.clientHeight) {
+    canvas.height = element.clientHeight;
+    canvas.style.height = `${element.clientHeight}px`;
+  }
 }
 
 /**


### PR DESCRIPTION
... because it flashes the canvas with IE and Edge (#172)