### PR TITLE
Feature/imageLoadObject.decache (#154)

### DIFF
--- a/src/imageCache.js
+++ b/src/imageCache.js
@@ -161,7 +161,7 @@ export function removeImageLoadObject (imageId) {
   };
 
   triggerEvent(events, 'cornerstoneimagecachechanged', eventDetails);
-  decache(cachedImage.imageLoadObject.promise);
+  decache(cachedImage.imageLoadObject);
 
   delete imageCacheDict[imageId];
 }
@@ -176,12 +176,19 @@ export function getCacheInfo () {
 
 // This method should only be called by `removeImageLoadObject` because it's
 // The one that knows how to deal with shared cache keys and cache size.
-function decache (imagePromise) {
-  imagePromise.then(function (image) {
-    if (image.decache) {
-      image.decache();
+function decache (imageLoadObject) {
+  imageLoadObject.promise.then(
+    function () {
+      if (imageLoadObject.decache) {
+        imageLoadObject.decache();
+      }
+    },
+    function () {
+      if (imageLoadObject.decache) {
+        imageLoadObject.decache();
+      }
     }
-  });
+  );
 }
 
 export function purgeCache () {


### PR DESCRIPTION
* imagePromise.decache

* decache when imagePromise is resolved or rejected

* removeImagePromise does not reject the image promise

* Wait for resolve or reject of imagePromise, before checking imagePromise.decache

* Removing the image.decache management, which I had kept for backward compatibility but which was in any case never used since imagePromise was rejected before.

* Revert "Removing the image.decache management, which I had kept for backward compatibility but which was in any case never used since imagePromise was rejected before."

This reverts commit 46e4df4cda5ac9903018ddd792ccc800b067b332.

* decache(imageLoadObject) (see PR #159 of cornerstoneWADOImageLoader)

* replace always(function) by then(function, function)